### PR TITLE
Python 3.7 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Update build tools
-      run: python -m pip install --upgrade pip setuptools
+      run: python -m pip install --upgrade pip setuptools wheel
 
     - name: Install Pydra tests dependencies (develop or setup.py install)
       if: matrix.install == 'develop' || matrix.install == 'install'

--- a/arcana/__about__.py
+++ b/arcana/__about__.py
@@ -16,6 +16,7 @@ install_requires = [
     'docker>=5.0.2',
     'neurodocker==0.7.0',
     'deepdiff>=3.3',
+    'importlib_metadata>=1.4',
     # Tests
     'pytest>=5.4.3',
     'pytest-env>=0.6.2',

--- a/arcana/core/data/item.py
+++ b/arcana/core/data/item.py
@@ -176,8 +176,9 @@ class FileGroup(DataItem):
                     "format ('{}')".format(
                         "', '".join(side_cars.keys()),
                         "', '".join(self.datatype.side_cars.keys())))
-            if missing_side_cars:= [f for f in side_cars.values()
-                                    if not op.exists(f)]:
+            missing_side_cars = [f for f in side_cars.values()
+                                 if not op.exists(f)]
+            if missing_side_cars:
                 raise ArcanaUsageError(
                     f"Attempting to set paths of auxiliary files for {self} "
                     "that don't exist ('{}')".format(

--- a/arcana/core/data/item.py
+++ b/arcana/core/data/item.py
@@ -129,10 +129,10 @@ class FileGroup(DataItem):
         if applicable
     fs_path : str | None
         Path to the primary file or directory on the local file system
-    side_cars : dict[str, str] | None
+    side_cars : ty.Dict[str, str] | None
         Additional files in the file_group. Keys should match corresponding
         side_cars dictionary in format.
-    checksums : dict[str, str]
+    checksums : ty.Dict[str, str]
         A checksums of all files within the file_group in a dictionary sorted
         bys relative file name_paths
     """

--- a/arcana/core/data/node.py
+++ b/arcana/core/data/node.py
@@ -37,7 +37,7 @@ class DataNode():
     frequency: DataDimensions = attr.ib()
     dataset: arcana.core.data.set.Dataset = attr.ib(repr=False)    
     children: ty.DefaultDict[DataDimensions,
-                             ty.Dict[str or tuple[str], str]] = attr.ib(
+                             ty.Dict[ty.Union[str, ty.Tuple[str]], str]] = attr.ib(
         factory=lambda: defaultdict(dict), repr=False)
     _unresolved = attr.ib(default=None, repr=False)
     _items = attr.ib(factory=dict, init=False, repr=False)
@@ -393,8 +393,9 @@ class UnresolvedField(UnresolvedDataItem):
         The data node that the field belongs to
     """
 
-    value: (int or float or str or ty.Sequence[int] or ty.Sequence[float]
-            or ty.Sequence[str]) = attr.ib(default=None)
+    value: ty.Union[
+        float, int, str, ty.List[float], ty.List[int], ty.List[str]
+    ] = attr.ib(default=None)
 
     def _resolve(self, datatype):
         try:

--- a/arcana/core/data/provenance.py
+++ b/arcana/core/data/provenance.py
@@ -19,7 +19,7 @@ class DataProvenance():
 
     Parameters
     ----------
-    dct : dict[str, Any]
+    dct : ty.Dict[str, Any]
         A dictionary containing the provenance record
     """
 
@@ -67,7 +67,7 @@ class DataProvenance():
         ----------
         name_path : str
             Path to save the generated JSON file
-        inputs : dict[str, str | ty.List[str] | ty.List[ty.List[str]]] | None
+        inputs : ty.Dict[str, str | ty.List[str] | ty.List[ty.List[str]]] | None
             Checksums of all pipeline inputs used by the pipeline. For inputs
             of matching frequency to the output sink associated with the
             provenance object, the values of the dictionary will be single
@@ -75,7 +75,7 @@ class DataProvenance():
             of checksums or in the case of 'per_session' inputs to 'per_dataset'
             outputs, lists of lists of checksum. They need to be provided here
             if the provenance object was initialised without checksums
-        outputs : dict[str, str] | None
+        outputs : ty.Dict[str, str] | None
             Checksums of all pipeline outputs. They need to be provided here
             if the provenance object was initialised without checksums
         """

--- a/arcana/core/data/set.py
+++ b/arcana/core/data/set.py
@@ -120,17 +120,19 @@ class Dataset():
 
     @column_specs.validator
     def column_specs_validator(self, _, column_specs):
-        if wrong_freq := [m for m in column_specs.values()
-                          if not isinstance(m.frequency, self.space)]:
+        wrong_freq = [m for m in column_specs.values()
+                    if not isinstance(m.frequency, self.space)]
+        if wrong_freq:
             raise ArcanaUsageError(
                 f"Data hierarchy of {wrong_freq} column specs do(es) not match"
                 f" that of dataset {self.space}")
 
     @excluded.validator
     def excluded_validator(self, _, excluded):
-        if both:= [f for f in self.included
-                   if (self.included[f] is not None
-                       and excluded[f] is not None)]:
+        both = [f for f in self.included
+                if (self.included[f] is not None
+                    and excluded[f] is not None)]
+        if both:
             raise ArcanaUsageError(
                     "Cannot provide both 'included' and 'excluded' arguments "
                     "for frequencies ('{}') to Dataset".format(
@@ -140,9 +142,11 @@ class Dataset():
     def hierarchy_validator(self, _, hierarchy):
         if not hierarchy:
             raise ArcanaUsageError(
-                f"hierarchy provided to {self} cannot be empty")            
-        if not_valid := [f for f in hierarchy
-                         if not isinstance(f, self.space)]:
+                f"hierarchy provided to {self} cannot be empty")
+
+        not_valid = [f for f in hierarchy
+                     if not isinstance(f, self.space)]
+        if not_valid:
             raise ArcanaWrongDataDimensionssError(
                 "{} are not part of the {} data dimensions"
                 .format(', '.join(not_valid), self.space))

--- a/arcana/core/data/set.py
+++ b/arcana/core/data/set.py
@@ -98,7 +98,7 @@ class Dataset():
         omitted or its value is None, then all available will be used
     workflows : Dict[str, pydra.Workflow]
         Workflows that have been applied to the dataset to generate sink
-    access_args: dict[str, Any]
+    access_args: ty.Dict[str, Any]
         Repository specific args used to control the way the dataset is accessed
     """
 
@@ -107,7 +107,7 @@ class Dataset():
     hierarchy: ty.List[DataDimensions] = attr.ib()
     id_inference: (ty.Dict[DataDimensions, str] or ty.Callable) = attr.ib(
         factory=dict, converter=default_if_none(factory=dict))
-    column_specs: ty.Dict[str, DataSource or DataSink] or None = attr.ib(
+    column_specs: ty.Optional[ty.Dict[str, ty.Union[DataSource, DataSink]]] = attr.ib(
         factory=dict, converter=default_if_none(factory=dict), repr=False)
     included: ty.Dict[DataDimensions, ty.List[str]] = attr.ib(
         factory=dict, converter=default_if_none(factory=dict), repr=False)
@@ -224,7 +224,7 @@ class Dataset():
             The frequency of the source within the dataset            
         overwrite : bool
             Whether to overwrite existing columns
-        **kwargs : dict[str, Any]
+        **kwargs : ty.Dict[str, Any]
             Additional kwargs to pass to DataSource.__init__
         """
         frequency = self._parse_freq(frequency)
@@ -573,7 +573,7 @@ class Dataset():
             connected to the inputs of the pipeline. If the pipelines requires
             the input to be in a format to the source, then it can be specified
             in a tuple (NAME, FORMAT)
-        outputs : Sequence[str or tuple[str, FileFormat]]
+        outputs : Sequence[ty.Union[str, ty.Tuple[str, FileFormat]]]
             List of sink names to be connected to the outputs of the pipeline
             If teh the input to be in a specific format, then it can be provided in
             a tuple (NAME, FORMAT)

--- a/arcana/core/data/type.py
+++ b/arcana/core/data/type.py
@@ -37,7 +37,7 @@ class FileFormat(object):
         A list of extensions that are found within the top level of
         the directory (for directory formats). Used to identify
         formats from paths.
-    side_cars : dict[str, str]
+    side_cars : ty.Dict[str, str]
         A dictionary of side cars (e.g. header or NIfTI json side cars) aside
         from the primary file, along with their expected extension.
         Automatically they will be assumed to be located adjancent to the
@@ -159,7 +159,7 @@ class FileFormat(object):
 
         Returns
         -------
-        aux_paths : dict[str, str]
+        aux_paths : ty.Dict[str, str]
             A dictionary of auxiliary file names and default paths
         """
         return dict((n, str(primary_path)[:-len(self.ext)] + ext)

--- a/arcana/core/pipeline.py
+++ b/arcana/core/pipeline.py
@@ -31,9 +31,9 @@ class Pipeline():
 
     wf: Workflow = attr.ib()
     frequency: DataDimensions = attr.ib()
-    inputs: ty.List[tuple[str, FileFormat]] = attr.ib(factory=list)
-    outputs: ty.List[tuple[str, FileFormat]] = attr.ib(factory=list)
-    _connected: set[str] = attr.ib(factory=set, repr=False)
+    inputs: ty.List[ty.Tuple[str, FileFormat]] = attr.ib(factory=list)
+    outputs: ty.List[ty.Tuple[str, FileFormat]] = attr.ib(factory=list)
+    _connected: ty.Set[str] = attr.ib(factory=set, repr=False)
 
     @property
     def lzin(self):
@@ -48,7 +48,7 @@ class Pipeline():
 
         Parameters
         ----------
-        connections : ty.List[tuple(str, ?)] or tuple(str, ?) or dict[str, ?]
+        connections : ty.List[ty.Tuple[str, ty.Any]] or ty.Tuple[str, ty.Any] or ty.Dict[str, ty.Any]
             The connections to set
 
         Raises
@@ -128,12 +128,12 @@ class Pipeline():
             Name of the pipeline
         dataset : Dataset
             The dataset to connect the pipeline to
-        inputs : Sequence[str or tuple[str, FileFormat]]
+        inputs : Sequence[ty.Union[str, ty.Tuple[str, FileFormat]]]
             List of column names (i.e. either data sources or sinks) to be
             connected to the inputs of the pipeline. If the pipelines requires
             the input to be in a format to the source, then it can be specified
             in a tuple (NAME, FORMAT)
-        outputs : Sequence[str or tuple[str, FileFormat]]
+        outputs : Sequence[ty.Union[str, ty.Tuple[str, FileFormat]]]
             List of sink names to be connected to the outputs of the pipeline
             If the input to be in a specific format, then it can be provided in
             a tuple (NAME, FORMAT)

--- a/arcana/core/pipeline.py
+++ b/arcana/core/pipeline.py
@@ -104,7 +104,8 @@ class Pipeline():
         return result
 
     def check_connections(self):
-        if missing:= set(self.output_names) - self._connected:
+        missing = set(self.output_names) - self._connected
+        if missing:
             raise Exception(
                 f"The following outputs haven't been connected: {missing}")
 

--- a/arcana/core/utils.py
+++ b/arcana/core/utils.py
@@ -65,9 +65,9 @@ def func_task(func, in_fields, out_fields, **inputs):
     ----------
     func : Callable
         The function to wrap
-    input_fields : ty.List[tuple[str, type]]
+    input_fields : ty.List[ty.Tuple[str, type]]
         The list of input fields to create for the task
-    output_fields : ty.List[tuple[str, type]]
+    output_fields : ty.List[ty.Tuple[str, type]]
         The list of output fields to create for the task
     **inputs
         Inputs to set for the task

--- a/arcana/core/utils.py
+++ b/arcana/core/utils.py
@@ -1,6 +1,6 @@
 from typing import Sequence
 import subprocess as sp
-import importlib.metadata
+import importlib_metadata
 import pkgutil
 import re
 from pathlib import Path
@@ -556,11 +556,11 @@ def get_pkg_name(module_path: str):
     """
     if not isinstance(module_path, str):
         module_path = module_path.__module__
-    module_path = importlib.metadata.PackagePath(module_path.replace('.', '/'))
+    module_path = importlib_metadata.PackagePath(module_path.replace('.', '/'))
     for pkg in pkg_resources.working_set:
         try:
-            paths = importlib.metadata.files(pkg.key)
-        except importlib.metadata.PackageNotFoundError:
+            paths = importlib_metadata.files(pkg.key)
+        except importlib_metadata.PackageNotFoundError:
             continue
         for path in paths:
             if path.suffix != '.py':

--- a/arcana/data/stores/bids.py
+++ b/arcana/data/stores/bids.py
@@ -271,7 +271,11 @@ class BidsDataset(Dataset):
         self.participants = {}
         with open(self.root_dir / 'participants.tsv') as f:
             cols = f.readline()[:-1].split('\t')
-            while line:= f.readline()[:-1]:
+            while True:
+                line = f.readline()[:-1]
+                if not line:
+                    break
+
                 d = dict(zip(cols, line.split('\t')))
                 self.participants[d.pop('participant_id')] = d
 

--- a/arcana/data/stores/bids.py
+++ b/arcana/data/stores/bids.py
@@ -391,10 +391,10 @@ class BidsApp:
         metadata={'help_string': 'Name of the BIDS app image to wrap'})
     executable: str = attr.ib(
         metadata={'help_string': 'Name of the executable within the image to run (i.e. the entrypoint of the image). Required when extending the base image and launching Arcana within it'})
-    inputs: ty.List[tuple[str, type, str]] = attr.ib(
+    inputs: ty.List[ty.Tuple[str, type, str]] = attr.ib(
         metadata={'help_string': (
             "The inputs to be inserted into the BIDS dataset (NAME, DTYPE, BIDS_PATH)")})
-    outputs: ty.List[tuple[str, type, ty.Optional[str]]] = attr.ib(
+    outputs: ty.List[ty.Tuple[str, type, ty.Optional[str]]] = attr.ib(
         converter=outputs_converter,
         metadata={'help_string': (
             "The outputs to be extracted from the derivatives directory (NAME, DTYPE, BIDS_PATH)")})
@@ -403,7 +403,7 @@ class BidsApp:
         default=None)
 
     def __call__(self, name=None, frequency: Clinical or str=Clinical.session,
-                 virtualisation: str=None, dataset: ty.Optional[str or Path or Dataset]=None) -> Workflow:
+                 virtualisation: str=None, dataset: ty.Optional[ty.Union[str, Path, Dataset]]=None) -> Workflow:
         """Creates a Pydra workflow which takes inputs and maps them to
         a BIDS dataset, executes a BIDS app and extracts outputs from
         the derivatives stored back in the BIDS dataset
@@ -460,7 +460,7 @@ class BidsApp:
             to_bids,
             in_fields=(
                 [('frequency', Clinical),
-                 ('inputs', ty.List[tuple[str, type, str]]),
+                 ('inputs', ty.List[ty.Tuple[str, type, str]]),
                  ('dataset', Dataset or str),
                  ('id', str)]
                 + [(i, str) for i in input_names]),
@@ -491,7 +491,7 @@ class BidsApp:
             in_fields=[
                 ('dataset', Dataset),
                 ('frequency', Clinical),
-                ('outputs', ty.List[tuple[str, type, str]]),
+                ('outputs', ty.List[ty.Tuple[str, type, str]]),
                 ('path_prefix', str),
                 ('id', str),
                 ('app_completed', bool)],
@@ -665,7 +665,7 @@ def dataset_paths(app_name: str, dataset: Dataset, id: str):
 
 def extract_bids(dataset: Dataset,
                  frequency: Clinical,
-                 outputs: ty.List[tuple[str, type, str]],
+                 outputs: ty.List[ty.Tuple[str, type, str]],
                  path_prefix: str,
                  id: str,
                  app_completed: bool):
@@ -692,7 +692,7 @@ def extract_bids(dataset: Dataset,
 @mark.task
 @mark.annotate(
     {'return':
-        {'bindings': ty.List[tuple[str, str, str]],
+        {'bindings': ty.List[ty.Tuple[str, str, str]],
          'tmp_output_dir': Path}})
 def make_bindings(dataset_path: str):
     """Make bindings for directories to be mounted inside the container

--- a/arcana/data/stores/tests/fixtures.py
+++ b/arcana/data/stores/tests/fixtures.py
@@ -64,8 +64,8 @@ class TestDatasetBlueprint():
     dim_lengths: ty.List[int]  # size of layers a-d respectively
     files: ty.List[str]  # files present at bottom layer
     id_inference: ty.Dict[DataDimensions, str]  # id_inference dict
-    expected_formats: ty.Dict[str, tuple[FileFormat, ty.List[str]]]  # expected formats
-    to_insert: ty.List[ty.Tuple[str, tuple[DataDimensions, FileFormat, ty.List[str]]]]  # files to insert as derivatives
+    expected_formats: ty.Dict[str, ty.Tuple[FileFormat, ty.List[str]]]  # expected formats
+    to_insert: ty.List[ty.Tuple[str, ty.Tuple[DataDimensions, FileFormat, ty.List[str]]]]  # files to insert as derivatives
 
 
 TEST_DATASET_BLUEPRINTS = {

--- a/arcana/data/stores/xnat/api.py
+++ b/arcana/data/stores/xnat/api.py
@@ -177,7 +177,7 @@ class Xnat(DataStore):
         -------
         primary_path : str
             The name_path of the primary file once it has been cached
-        side_cars : dict[str, str]
+        side_cars : ty.Dict[str, str]
             A dictionary containing a mapping of auxiliary file names to
             name_paths
         """
@@ -267,7 +267,7 @@ class Xnat(DataStore):
 
         Returns
         -------
-        value : float or int or str of ty.List[float] or ty.List[int] or ty.List[str]
+        value : ty.Union[float, int, str, ty.List[float], ty.List[int], ty.List[str]]
             The value of the field
         """
         if file_group.datatype is None:
@@ -352,7 +352,7 @@ class Xnat(DataStore):
 
         Returns
         -------
-        value : float or int or str of ty.List[float] or ty.List[int] or ty.List[str]
+        value : ty.Union[float, int, str, ty.List[float], ty.List[int], ty.List[str]]
             The value of the field
         """
         self._check_store(field)

--- a/arcana/data/stores/xnat/cs.py
+++ b/arcana/data/stores/xnat/cs.py
@@ -202,9 +202,9 @@ class XnatViaCS(Xnat):
             The module path to the task to execute
         image_tag : str
             Name + version of the Docker image to be created
-        inputs : ty.List[InputArg or tuple]
+        inputs : ty.List[ty.Union[InputArg, tuple]]
             Inputs to be provided to the container (pydra_field, datatype, dialog_name, FREQUENCY)
-        outputs : ty.List[OutputArg or tuple]
+        outputs : ty.List[ty.Union[OutputArg, tuple]]
             Outputs from the container 
         description : str
             User-facing description of the pipeline
@@ -469,8 +469,8 @@ class XnatViaCS(Xnat):
 
     @classmethod
     def generate_dockerfile(cls,
-                            xnat_commands: ty.List[ty.Dict[str, str or dict or list]],
-                            python_packages: ty.List[tuple[str, str]],
+                            xnat_commands: ty.List[ty.Dict[str, ty.Union[str, dict, list]]],
+                            python_packages: ty.List[ty.Tuple[str, str]],
                             maintainer: str,
                             build_dir: Path=None,
                             base_image: str=None,
@@ -497,7 +497,7 @@ class XnatViaCS(Xnat):
             Name and version of the Python PyPI packages to add to the image
         registry
             URI of the Docker registry to upload the image to
-        extra_labels : dict[str, str], optional
+        extra_labels : ty.Dict[str, str], optional
             Additional labels to be added to the image
 
         Returns

--- a/arcana/data/stores/xnat/tests/fixtures.py
+++ b/arcana/data/stores/xnat/tests/fixtures.py
@@ -27,9 +27,9 @@ from arcana.data.stores.tests.fixtures import create_test_file
 class TestDatasetBlueprint():
 
     dim_lengths: ty.List[int]
-    scans: ty.List[ty.Tuple[str, ty.List[tuple[str, FileFormat, ty.List[str]]]]]
+    scans: ty.List[ty.Tuple[str, ty.List[ty.Tuple[str, FileFormat, ty.List[str]]]]]
     id_inference: ty.Dict[DataDimensions, str]
-    to_insert: ty.List[ty.Tuple[str, tuple[DataDimensions, FileFormat, ty.List[str]]]]  # files to insert as derivatives
+    to_insert: ty.List[ty.Tuple[str, ty.Tuple[DataDimensions, FileFormat, ty.List[str]]]]  # files to insert as derivatives
 
 
 TEST_DATASET_BLUEPRINTS = {

--- a/arcana/data/types/neuroimaging.py
+++ b/arcana/data/types/neuroimaging.py
@@ -283,10 +283,10 @@ class MrtrixImage(BaseImage):
         return hdr, array
 
     def get_header(self, fileset):
-        self._load_header_and_array(fileset)[0]
+        return self._load_header_and_array(fileset)[0]
 
     def get_array(self, fileset):
-        self._load_header_and_array(fileset)[1]
+        return self._load_header_and_array(fileset)[1]
 
     def get_vox_sizes(self, fileset):
         return self.get_header(fileset)['vox']

--- a/arcana/entrypoints/run.py
+++ b/arcana/entrypoints/run.py
@@ -200,7 +200,7 @@ class RunCmd(BaseDatasetCmd):
 
         Returns
         -------
-        ty.List[tuple[str, FileFormat]]
+        ty.List[ty.Tuple[str, FileFormat]]
             A sequence of input names and their required formats
 
         Raises
@@ -240,7 +240,7 @@ class RunCmd(BaseDatasetCmd):
 
         Returns
         -------
-        ty.List[tuple[str, FileFormat]]
+        ty.List[ty.Tuple[str, FileFormat]]
             A sequence of input names and the formats they are produced in
         """
         frequency = cls.parse_frequency(args)

--- a/arcana/tasks/archive.py
+++ b/arcana/tasks/archive.py
@@ -1,4 +1,5 @@
 import os.path
+import sys
 import tempfile
 import tarfile
 import zipfile
@@ -100,10 +101,18 @@ def create_zip(in_file, out_file, base_dir, compression='', allowZip64=True,
 
     out_file = os.path.abspath(out_file)
 
+    zip_kwargs = {}
+    if not strict_timestamps:  # Truthy is the default in earlier versions
+        if sys.version_info.major <= 3 and sys.version_info.minor < 8:
+            raise Exception("Must be using Python >= 3.8 to pass "
+                            f"strict_timestamps={strict_timestamps!r}")
+
+        zip_kwargs['strict_timestamps'] = strict_timestamps
+
     with zipfile.ZipFile(
             out_file, mode='w', compression=ZIP_COMPRESSION_TYPES[compression],
             allowZip64=allowZip64, compresslevel=compresslevel,
-            strict_timestamps=strict_timestamps) as zfile, set_cwd(base_dir):
+            **zip_kwargs) as zfile, set_cwd(base_dir):
         for path in in_file:
             path = Path(path)
             if path.is_dir():


### PR DESCRIPTION
* Python 3.8 compatibility
    * Type annotations with typings module
* Python 3.7 compatibility
    * Remove usage of assignment expressions `:=`
    * Replace usages of `importlib.metadata` with `importlib_metadata` (already pulled in by `sphinx`)
* Add some [missing return statements](https://github.com/Australian-Imaging-Service/arcana/commit/66324dafa428b62f011520bcb071b4478d48b1e1)
* Explicitly install `wheel` package before running tests, fixes `bdist_wheel` errors
* [Throw an exception on python <= 3.7 if `strict_timestamps=False` is passed, as this option was only added in Python 3.8](https://github.com/Australian-Imaging-Service/arcana/commit/7d65d61bbd16b14207742df4545f78b8114ab20f)