### PR TITLE
Yaml pipelines

### DIFF
--- a/arcana/cli/__init__.py
+++ b/arcana/cli/__init__.py
@@ -1,6 +1,6 @@
 from arcana.core.cli import cli
 from .column import column
 from .dataset import dataset
+from .deploy import deploy
 from .run import run
 from .store import store
-from .wrap import wrap

--- a/arcana/cli/deploy.py
+++ b/arcana/cli/deploy.py
@@ -11,12 +11,13 @@ from arcana.data.spaces.medicalimaging import ClinicalTrial
 
 DOCKER_REGISTRY = 'docker.io'
 
+
 @cli.group()
-def wrap():
+def deploy():
     pass
 
 
-@wrap.command(help="""Build a wrapper image specified in a module
+@deploy.command(help="""Build a wrapper image specified in a module
 
 module_path
     The file system path to the module to build""")
@@ -54,7 +55,7 @@ spec_help = """
 """
 
 
-@wrap.command(name='build-all', help=f"""Build all wrapper images specified
+@deploy.command(name='build-all', help=f"""Build all wrapper images specified
 in sub-modules under the package path.
 
 Arguments
@@ -93,7 +94,7 @@ def build_all(package_path, registry, loglevel, build_dir):
     click.echo('\n'.join(built_images))
 
 
-@wrap.command(name='docs', help="""Build docs for one or more yaml wrapppers
+@deploy.command(name='docs', help="""Build docs for one or more yaml wrappers
 
 SPEC is the path of a YAML spec file or directory containing one or more such files.
 
@@ -117,7 +118,7 @@ def build_docs(spec, output, flatten):
         create_doc(spec_info, output, spec_info['_module_name'], flatten=flatten)
 
 
-@wrap.command(name='test', help="""Test a wrapper pipeline defined in a module
+@deploy.command(name='test', help="""Test a wrapper pipeline defined in a module
 
 Arguments
 ---------
@@ -128,7 +129,7 @@ def test(module_path):
     raise NotImplementedError
 
 
-@wrap.command(name='test-all', help="""Test all wrapper pipelines
+@deploy.command(name='test-all', help="""Test all wrapper pipelines
 in a package.
 
 Arguments

--- a/arcana/cli/tests/test_wrap.py
+++ b/arcana/cli/tests/test_wrap.py
@@ -1,7 +1,7 @@
 import tempfile
 from pathlib import Path
 from click.testing import CliRunner
-from arcana.cli.wrap import build_all
+from arcana.cli.deploy import build_all
 
 def test_wrap4xnat():
 


### PR DESCRIPTION
Example pipeline yaml config: https://gist.github.com/Prepultrue/1951ba5658c848532c83bf8de7747cd3

Read pipeline info from yaml config files instead of importing arbitrary Python modules.

Doesn't yet initialise a BidsApp instance with the values.