### PR TITLE
Move __version__ out of _version as it's auto generated

### DIFF
--- a/arcana/__init__.py
+++ b/arcana/__init__.py
@@ -24,5 +24,8 @@ from .core.data.set import Dataset
 # Should be set explicitly in all FSL interfaces, but this squashes the warning
 # os.environ['FSLOUTPUTTYPE'] = 'NIFTI_GZ'
 
-from ._version import __version__
 from .__about__ import __authors__
+
+from ._version import get_versions
+__version__ = get_versions()['version']
+del get_versions

--- a/arcana/_version.py
+++ b/arcana/_version.py
@@ -642,5 +642,3 @@ def get_versions():
     return {"version": "0+unknown", "full-revisionid": None,
             "dirty": None,
             "error": "unable to compute version", "date": None}
-
-__version__ = get_versions()['version']

--- a/arcana/core/utils.py
+++ b/arcana/core/utils.py
@@ -16,10 +16,14 @@ from contextlib import contextmanager
 from collections.abc import Iterable
 import logging
 import attr
-from arcana._version import __version__
 from pydra.engine.task import FunctionTask
 from pydra.engine.specs import BaseSpec, SpecInfo
 from arcana.exceptions import ArcanaUsageError, ArcanaNameError, ArcanaVersionError
+
+# Avoid arcana.__version__ causing a circular import
+from arcana._version import get_versions
+__version__ = get_versions()['version']
+del get_versions
 
 
 PATH_SUFFIX = '_path'


### PR DESCRIPTION
Move `__version__` out of `_version.py` as it's automatically generated on build