### PR TITLE
Enables `run-arcana-pipeline` to be run on a single row of the dataset

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Arcana
 ======
 .. image:: https://github.com/australian-imaging-service/arcana/actions/workflows/tests.yml/badge.svg
    :target: https://github.com/australian-imaging-service/arcana/actions/workflows/tests.yml
-.. image:: https://codecov.io/gh/australian-imaging-service/arcana/branch/master/graph/badge.svg
+.. image:: https://codecov.io/gh/australian-imaging-service/arcana/branch/main/graph/badge.svg?token=UIS0OGPST7
    :target: https://codecov.io/gh/australian-imaging-service/arcana
 .. image:: https://img.shields.io/pypi/pyversions/arcana.svg
    :target: https://pypi.python.org/pypi/arcana/

--- a/arcana/cli/deploy.py
+++ b/arcana/cli/deploy.py
@@ -37,7 +37,7 @@ containing multiple specifications
 DOCKER_ORG is the Docker organisation the images should belong to""")
 @click.argument('spec_path', type=click.Path(exists=True, path_type=Path))
 @click.argument('docker_org', type=str)
-@click.option('--registry', 'docker_registry', default=None,
+@click.option('--registry', 'docker_registry', default=DOCKER_HUB,
               help="The Docker registry to deploy the pipeline to")
 @click.option('--build_dir', default=None,
               type=click.Path(exists=True, path_type=Path),
@@ -89,14 +89,15 @@ def build(spec_path, docker_org, docker_registry, loglevel, build_dir,
         # Make image tag
         pkg_name = spath.stem.lower()
         tag = '.'.join(spath.relative_to(spec_path).parent.parts + (pkg_name,))
+
         image_version = str(spec.pop('pkg_version'))
         if 'wrapper_version' in spec:
             image_version += f"-{spec.pop('wrapper_version')}"
+
         image_tag = f"{docker_org}/{tag}:{image_version}"
-        if docker_registry is not None:
+
+        if docker_registry != DOCKER_HUB:
             image_tag = docker_registry.lower() + '/' + image_tag
-        else:
-            docker_registry = DOCKER_HUB
 
         try:
             build_xnat_cs_image(

--- a/arcana/cli/tests/test_deploy_cli.py
+++ b/arcana/cli/tests/test_deploy_cli.py
@@ -53,9 +53,9 @@ def test_run_pipeline_cli(concatenate_task, saved_dataset, cli_runner, work_dir)
     result = cli_runner(
         run_pipeline,
         [dataset_id_str, 'a_pipeline', 'arcana.test.tasks:' + concatenate_task.__name__,
-         '--input', 'file1', 'common:Text', 'in_file1', 'common:Text',
-         '--input', 'file2', 'common:Text', 'in_file2', 'common:Text',
-         '--output', 'concatenated', 'common:Text', 'out_file', 'common:Text',
+         '--input', 'source1', 'common:Text', 'file1', 'in_file1', 'common:Text',
+         '--input', 'source2', 'common:Text', 'file2', 'in_file2', 'common:Text',
+         '--output', 'sink1', 'common:Text', 'concatenated', 'out_file', 'common:Text',
          '--parameter', 'duplicates', str(duplicates),
          '--plugin', 'serial',
          '--work', str(work_dir),

--- a/arcana/core/data/format.py
+++ b/arcana/core/data/format.py
@@ -12,7 +12,7 @@ from abc import ABCMeta, abstractmethod
 import attr
 from attr.converters import optional
 from pydra.engine.core import LazyField, Workflow
-from arcana.core.utils import class_location, parse_value, func_task
+from arcana.core.utils import class_location, parse_value, func_task, path2varname
 from arcana.exceptions import (
     ArcanaUnresolvableFormatException, ArcanaUsageError, ArcanaNameError, ArcanaUsageError,
     ArcanaDataNotDerivedYetError, ArcanaFileFormatError, ArcanaFormatConversionError)
@@ -632,7 +632,7 @@ def access_paths(from_format, file_group):
     """Copies files into the CWD renaming so the basenames match
     except for extensions"""
     logger.debug("Extracting paths from %s (%s format) before conversion", file_group, from_format)
-    cpy = file_group.copy_to(Path(file_group.path).name, symlink=True)
+    cpy = file_group.copy_to(path2varname(file_group.path), symlink=True)
     return cpy.fs_paths if len(cpy.fs_paths) > 1 else cpy.fs_path
 
 

--- a/arcana/core/data/set.py
+++ b/arcana/core/data/set.py
@@ -272,10 +272,12 @@ class Dataset():
             The root node of the data tree
         """
         if self._root_node is None:
-            self._root_node = DataNode({self.root_freq: None}, self.root_freq,
-                                       self)
+            self._set_root_node()
             self.store.find_nodes(self)
         return self._root_node
+
+    def _set_root_node(self):
+        self._root_node = DataNode({self.root_freq: None}, self.root_freq, self)
 
     def refresh(self):
         """Refresh the dataset nodes"""
@@ -403,6 +405,7 @@ class Dataset():
                 except KeyError as e:
                     raise ArcanaNameError(
                         id, f"{id} ({freq}) not a child node of {node}") from e
+            return node
         else:
             try:
                 return self.root_node.children[frequency][id]
@@ -493,6 +496,8 @@ class Dataset():
             raised if one of the groups specified in the ID inference reg-ex
             doesn't match a valid frequency in the data dimensions
         """
+        if self._root_node is None:
+            self._set_root_node()
         if explicit_ids is None:
             explicit_ids = {}
         # Get basis frequencies covered at the given depth of the
@@ -565,6 +570,7 @@ class Dataset():
                     if len(id) == 1:
                         id = id[0]
                     ids[freq] = id
+        # TODO: filter node based on dataset include & exlcude attrs
         return self.add_node(ids, frequency)
 
     def add_node(self, ids, frequency):

--- a/arcana/core/deploy/build.py
+++ b/arcana/core/deploy/build.py
@@ -262,7 +262,7 @@ def install_arcana(dockerfile: DockerRenderer,
     if install_extras:
         pip_str += '[' + ','.join(install_extras) + ']'
     dockerfile.run(
-        f'bash -c "source activate {CONDA_ENV} \\'
+        f'bash -c "source activate {CONDA_ENV} \\\n'
         f'&& python -m pip install --no-cache-dir {pip_str}"')
 
 

--- a/arcana/core/deploy/build.py
+++ b/arcana/core/deploy/build.py
@@ -1,5 +1,6 @@
 import typing as ty
 from pathlib import Path
+import json
 import tempfile
 import logging
 import shutil
@@ -128,7 +129,8 @@ def construct_dockerfile(
     if labels:
         # dockerfile.label(labels)
         dockerfile._parts.append(
-            "LABEL " + " \\\n      ".join(f'{k}="{v}"' for k, v in labels.items()))
+            "LABEL " + " \\\n      ".join(
+                f'{k}={json.dumps(v)}' for k, v in labels.items()))
 
     return dockerfile
 

--- a/arcana/core/deploy/build.py
+++ b/arcana/core/deploy/build.py
@@ -153,7 +153,7 @@ def dockerfile_build(dockerfile: DockerRenderer, build_dir: Path, image_tag: str
     out_file.parent.mkdir(exist_ok=True, parents=True)
     with open(str(out_file), 'w') as f:
         f.write(dockerfile.render())
-    logger.info("Dockerfile generated at %s", str(out_file))
+    logger.info("Dockerfile for '%s' generated at %s", image_tag, str(out_file))
     
     dc = docker.from_env()
     dc.images.build(path=str(build_dir), tag=image_tag)

--- a/arcana/core/deploy/build.py
+++ b/arcana/core/deploy/build.py
@@ -54,6 +54,7 @@ def construct_dockerfile(
         arcana_install_extras: ty.Iterable[str]=(),
         readme: str=None,
         use_local_packages: bool=False,
+        pypi_fallback: bool=False,
         license_dir: Path=None,
         licenses: ty.Iterable[ty.Dict[str, str]]=()) -> DockerRenderer:
     """Constructs a dockerfile that wraps a with dependencies
@@ -86,9 +87,15 @@ def construct_dockerfile(
         Use the python package versions that are installed within the
         current environment, i.e. instead of pulling from PyPI. Useful during
         development and testing
+    pypi_fallback : bool, optional
+        whether to fallback to packages installed on PyPI when versions of
+        local packages don't match installed
     license_dir : Path, optional
         path to the directory containing the licence files to copy into the
         image
+    licenses : list[dict[str, str]], optional
+        specification of licences to install inside docker image. Each dict
+        should contain 'source' and 'destination' items.
 
     Returns
     -------
@@ -117,7 +124,8 @@ def construct_dockerfile(
         install_package_templates(dockerfile, package_templates)
 
     install_python(dockerfile, python_packages, build_dir,
-                   use_local_packages=use_local_packages)
+                   use_local_packages=use_local_packages,
+                   pypi_fallback=pypi_fallback)
 
     install_arcana(dockerfile, build_dir, arcana_install_extras)
 
@@ -162,7 +170,8 @@ def dockerfile_build(dockerfile: DockerRenderer, build_dir: Path, image_tag: str
 
 def install_python(dockerfile: DockerRenderer,
                    packages: ty.Iterable[PipSpec], build_dir: Path,
-                   use_local_packages: bool=False):
+                   use_local_packages: bool=False,
+                   pypi_fallback: bool=False):
     """Generate Neurodocker instructions to install an appropriate version of
     Python and the required Python packages
 
@@ -181,6 +190,9 @@ def install_python(dockerfile: DockerRenderer,
         Use the python package versions that are installed within the
         current environment, i.e. instead of defaulting to the release from PyPI.
         Useful during development and testing
+    pypi_fallback : bool, optional
+        Whether to fall back to PyPI version when local version doesn't match
+        requested
 
     Returns
     -------
@@ -201,7 +213,8 @@ def install_python(dockerfile: DockerRenderer,
     instructions = []
     for pip_spec in packages:
         if use_local_packages:
-            pip_spec = local_package_location(pip_spec)
+            pip_spec = local_package_location(pip_spec,
+                                              pypi_fallback=pypi_fallback)
         if pip_spec.file_path:
             if pip_spec.version or pip_spec.url:
                 raise ArcanaBuildError(

--- a/arcana/core/deploy/utils.py
+++ b/arcana/core/deploy/utils.py
@@ -211,5 +211,5 @@ def local_package_location(pip_spec: PipSpec, pypi_fallback: bool=True):
 
 
 
-DOCKER_HUB = 'index.docker.io/v1/'
+DOCKER_HUB = 'docker.io'
 site_pkg_locs = [Path(p).resolve() for p in site.getsitepackages()]

--- a/arcana/core/deploy/utils.py
+++ b/arcana/core/deploy/utils.py
@@ -26,6 +26,11 @@ class PipSpec():
     file_path: str = None
     extras: ty.List[str] = dataclass_field(default_factory=list)
 
+    def __post_init__(self):
+        if self.version and not isinstance(self.version, str):
+            self.version = str(self.version)
+
+
     @classmethod
     def unique(cls, pip_specs: ty.Iterable, remove_arcana: bool=False):
         """Merge a list of Pip install specs so each package only appears once

--- a/arcana/core/deploy/utils.py
+++ b/arcana/core/deploy/utils.py
@@ -211,5 +211,5 @@ def local_package_location(pip_spec: PipSpec, pypi_fallback: bool=True):
 
 
 
-DOCKER_HUB = 'https://index.docker.io/v1/'
+DOCKER_HUB = 'index.docker.io/v1/'
 site_pkg_locs = [Path(p).resolve() for p in site.getsitepackages()]

--- a/arcana/core/deploy/utils.py
+++ b/arcana/core/deploy/utils.py
@@ -137,7 +137,7 @@ def walk_spec_paths(spec_path: Path) -> ty.Iterable[Path]:
                 yield path
 
 
-def local_package_location(pip_spec: PipSpec, pypi_fallback: bool=True):
+def local_package_location(pip_spec: PipSpec, pypi_fallback: bool=False):
     """Detect the installed locations of the packages, including development
     versions.
 
@@ -145,7 +145,7 @@ def local_package_location(pip_spec: PipSpec, pypi_fallback: bool=True):
     ----------
     package : [PipSpec]
         the packages (or names of) the versions to detect
-    pypi_fallback : bool
+    pypi_fallback : bool, optional
         Fallback to PyPI version if requested version isn't installed locally
 
     Returns

--- a/arcana/core/tests/test_utils.py
+++ b/arcana/core/tests/test_utils.py
@@ -7,11 +7,15 @@ def test_package_from_module():
 
 
 def test_path2varname():
-    escape_pairs = [('func/task-rest_bold', 'func__l__task__H__rest_bold'),
-                    ('__a.very$illy*ath~', 'XXX_dunder_a__o__very__dollar__illy__star__ath__tilde__'),
+    escape_pairs = [('func/task-rest_bold', 'func__l__task__H__rest_u_bold'),
+                    ('with spaces and__ underscores',
+                     'with__s__spaces__s__and_u__u___s__underscores'),
+                    ('__a.very$illy*ath~',
+                     'XXX_u__u_a__o__very__dollar__illy__star__ath__tilde__'),
                     ('anat/T1w', 'anat__l__T1w'),
-                    ('anat__l__T1w', 'anat_dunder_l_dunder_T1w')]
-
+                    ('anat__l__T1w', 'anat_u__u_l_u__u_T1w'),
+                    ('_u__u_', 'XXX_u_u_u__u_u_u_')]
     for path, varname in escape_pairs:
         assert path2varname(path) == varname
         assert varname2path(varname) == path
+        assert varname2path(varname2path(path2varname(path2varname(path)))) == path

--- a/arcana/core/utils.py
+++ b/arcana/core/utils.py
@@ -73,9 +73,11 @@ def get_config_file_path(name: str):
 
 # Escape values for invalid characters for Python variable names
 PATH_ESCAPES = {
-    '__': '_dunder_',
+    '_': '_u_',
     '/': '__l__',
     '.': '__o__',
+    ' ': '__s__',
+    '\t': '__t__',
     ',': '__comma__',
     '>': '__gt__',
     '<': '__lt__',

--- a/arcana/deploy/medimage/xnat.py
+++ b/arcana/deploy/medimage/xnat.py
@@ -306,6 +306,7 @@ def generate_xnat_cs_command(name: str,
         f"--work {XnatViaCS.WORK_MOUNT} "  # working directory
         f"--dataset_space medimage:Clinical "
         f"--dataset_hierarchy subject,session "
+        "--single-row [SUBJECT_LABEL],[SESSION_LABEL] "
         f"--frequency {frequency} ")  # pass XNAT API details
         # TODO: add option for whether to overwrite existing pipeline
 
@@ -328,7 +329,7 @@ def generate_xnat_cs_command(name: str,
         # Create Session input that  can be passed to the command line, which
         # will be populated by inputs derived from the XNAT session object
         # passed to the pipeline.
-        inputs_json.append(
+        inputs_json.extend([
             {
                 "name": "SESSION_LABEL",
                 "description": "Imaging session label",
@@ -336,7 +337,16 @@ def generate_xnat_cs_command(name: str,
                 "required": True,
                 "user-settable": False,
                 "replacement-key": "[SESSION_LABEL]"
-            })
+            },
+            {
+                "name": "SUBJECT_LABEL",
+                "description": "Subject label",
+                "type": "string",
+                "required": True,
+                "user-settable": False,
+                "replacement-key": "[SUBJECT_LABEL]"
+            }
+            ])
         # Add specific session to process to command line args
         cmdline += " --ids [SESSION_LABEL] "
         # Access the session XNAT object passed to the pipeline
@@ -363,6 +373,14 @@ def generate_xnat_cs_command(name: str,
                 "derived-from-wrapper-input": "SESSION",
                 "derived-from-xnat-object-property": "label",
                 "provides-value-for-command-input": "SESSION_LABEL",
+                "user-settable": False
+            },
+            {
+                "name": "__SUBJECT_ID__",
+                "type": "string",
+                "derived-from-wrapper-input": "SESSION",
+                "derived-from-xnat-object-property": "subject-id",
+                "provides-value-for-command-input": "SUBJECT_LABEL",
                 "user-settable": False
             },
             {

--- a/arcana/deploy/medimage/xnat.py
+++ b/arcana/deploy/medimage/xnat.py
@@ -108,13 +108,14 @@ def generate_xnat_cs_command(name: str,
                              image_tag: str,
                              inputs,
                              outputs,
-                             description,
-                             version,
-                             info_url,
+                             description: str,
+                             version: str,
+                             info_url: str,
                              parameters=None,
                              configuration=None,
                              frequency='session',
-                             registry=DOCKER_HUB):
+                             registry=DOCKER_HUB,
+                             long_description: str=None):
     """Constructs the XNAT CS "command" JSON config, which specifies how XNAT
     should handle the containerised pipeline
 
@@ -151,6 +152,10 @@ def generate_xnat_cs_command(name: str,
     configuration : dict[str, Any]
         Fixed arguments passed to the workflow at initialisation. Can be used to specify
         the input fields of the workflow/task
+    long_description : str
+        A long description of the pipeline, used in documentation and ignored
+        here. Only included in the signature so that an error isn't thrown when
+        it is encountered.
 
     Returns
     -------

--- a/arcana/deploy/medimage/xnat.py
+++ b/arcana/deploy/medimage/xnat.py
@@ -82,9 +82,7 @@ def build_xnat_cs_image(image_tag: str,
 
     # Convert XNAT command label into string that can by placed inside the
     # Docker label
-    command_label = '[' + ', \\\n\t'.join(
-        json.dumps(c).replace('"', r'\"').replace('$', r'\$')
-        for c in xnat_commands) + ']'
+    command_label = json.dumps(xnat_commands).replace('$', r'\$')
 
     dockerfile = construct_dockerfile(
         build_dir,
@@ -288,7 +286,7 @@ def generate_xnat_cs_command(name: str,
     # Set up fixed arguments used to configure the workflow at initialisation
     config_args = []
     for cname, cvalue in configuration.items():
-        cvalue_json = json.dumps(cvalue).replace('"', '\\"')
+        cvalue_json = json.dumps(cvalue)  #.replace('"', '\\"')
         config_args.append(f"--configuration {cname} '{cvalue_json}' ")
 
     input_args_str = ' '.join(input_args)

--- a/arcana/deploy/medimage/xnat.py
+++ b/arcana/deploy/medimage/xnat.py
@@ -32,6 +32,8 @@ def build_xnat_cs_image(image_tag: str,
                         build_dir: Path=None,
                         test_config: bool=False,
                         generate_only: bool=False,
+                        pkg_version: str=None, # Ignored here, just included to allow specs to be passed directly as kwargs
+                        wrapper_version: str=None, # ditto
                         **kwargs):
     """Creates a Docker image containing one or more XNAT commands ready
     to be installed in XNAT's container service plugin
@@ -98,7 +100,7 @@ def build_xnat_cs_image(image_tag: str,
     if not generate_only:
         dockerfile_build(dockerfile, build_dir, image_tag)
 
-    return build_dir
+    return dockerfile
 
 
 def generate_xnat_cs_command(name: str,

--- a/arcana/tasks/bids/app.py
+++ b/arcana/tasks/bids/app.py
@@ -23,8 +23,8 @@ from arcana.core.utils import func_task, path2varname, resolve_class
 @dataclass
 class Input():
 
-    format: type
     path: str
+    format: type
     name: str = None
 
     def __post_init__(self):

--- a/arcana/tasks/bids/app.py
+++ b/arcana/tasks/bids/app.py
@@ -27,6 +27,12 @@ class Input():
     format: type
     name: str = None
 
+    @classmethod
+    def fromdict(cls, dct):
+        return cls(path=dct['path'],
+                   format=dct['format'],
+                   name=dct['name'])
+
     def __post_init__(self):
         if isinstance(self.format, str):
             self.format = resolve_class(self.format,
@@ -109,8 +115,8 @@ def bids_app(name: str,
             subject_ids=[DEFAULT_BIDS_ID])
 
     # Convert from JSON format inputs/outputs to tuples with resolved data formats
-    inputs = [Input(**i) if not isinstance(i, Input) else i for i in inputs]
-    outputs = [Output(**o) if not isinstance(o, Output) else o for o in outputs]
+    inputs = [Input.fromdict(i) if not isinstance(i, Input) else i for i in inputs]
+    outputs = [Output.fromdict(o) if not isinstance(o, Output) else o for o in outputs]
 
     # Ensure output paths all start with 'derivatives
     input_names = [i.name for i in inputs]

--- a/arcana/tasks/bids/app.py
+++ b/arcana/tasks/bids/app.py
@@ -6,6 +6,7 @@ import shutil
 import shlex
 from argparse import ArgumentParser
 from pathlib import Path
+from dataclasses import dataclass
 from arcana import __version__
 from pydra import Workflow, mark
 from pydra.engine.task import (
@@ -16,12 +17,33 @@ from arcana.core.data.set import Dataset
 from arcana.data.spaces.medimage import Clinical
 from arcana.data.stores.bids.dataset import BidsDataset
 from arcana.exceptions import ArcanaUsageError
-from arcana.core.utils import func_task, path2varname, varname2path, resolve_class
+from arcana.core.utils import func_task, path2varname, resolve_class
+
+
+@dataclass
+class Input():
+
+    format: type
+    path: str
+    name: str = None
+
+    def __post_init__(self):
+        if isinstance(self.format, str):
+            self.format = resolve_class(self.format,
+                                        prefixes=['arcana.data.formats'])
+        if self.name is None:
+            self.name = path2varname(self.path)
+
+
+# Definition of output is the same as Input but we keep it separate in case we
+# need to change it later
+class Output(Input):  
+    pass
 
 
 def bids_app(name: str,
-             inputs: ty.List[ty.Tuple[str, type] or ty.Dict[str, str]],
-             outputs: ty.List[ty.Tuple[str, type] or ty.Dict[str, str]],
+             inputs: ty.List[Input or ty.Dict[str, str]],
+             outputs: ty.List[Output or ty.Dict[str, str]],
              executable: str='',  # Use entrypoint of container,
              container_image: str= None,
              parameters: ty.Dict[str, type]=None,
@@ -87,14 +109,12 @@ def bids_app(name: str,
             subject_ids=[DEFAULT_BIDS_ID])
 
     # Convert from JSON format inputs/outputs to tuples with resolved data formats
-    inputs = [(i['path'], resolve_class(i['format'], prefixes=['arcana.data.formats']))
-               if isinstance(i, dict) else i for i in inputs]
-    outputs = [(o['path'], resolve_class(o['format'], prefixes=['arcana.data.formats']))
-               if isinstance(o, dict) else o for o in outputs]
+    inputs = [Input(**i) if not isinstance(i, Input) else i for i in inputs]
+    outputs = [Output(**o) if not isinstance(o, Output) else o for o in outputs]
 
     # Ensure output paths all start with 'derivatives
-    input_names = [path2varname(i[0]) for i in inputs]
-    output_names = [path2varname(o[0]) for o in outputs]
+    input_names = [i.name for i in inputs]
+    output_names = [o.name for o in outputs]
 
     input_spec = set(['id', 'flags', 'json_edits'] + input_names + list(parameters))
     workflow = Workflow(
@@ -304,9 +324,10 @@ def bidsify_id(id):
 def to_bids(frequency, inputs, dataset, id, json_edits, **input_values):
     """Takes generic inptus and stores them within a BIDS dataset
     """
+    # Update the Bids store with the JSON edits requested by the user
     dataset.store.json_edits = parse_json_edits(json_edits)
-    for inpt_path, inpt_type in inputs:
-        dataset.add_sink(path2varname(inpt_path), inpt_type, path=inpt_path)
+    for inpt in inputs:
+        dataset.add_sink(inpt.name, inpt.format, path=inpt.path)
     data_node = dataset.node(frequency, id)
     with dataset.store:
         for inpt_name, inpt_value in input_values.items():
@@ -345,12 +366,12 @@ def extract_bids(dataset: Dataset,
     """
     output_paths = []
     data_node = dataset.node(frequency, id)
-    for output_path, output_type in outputs:
-        dataset.add_sink(path2varname(output_path), output_type,
-                         path=path_prefix + '/' + output_path)
+    for output in outputs:
+        dataset.add_sink(output.name, output.format,
+                         path=path_prefix + '/' + output.path)
     with dataset.store:
         for output in outputs:
-            item = data_node[path2varname(output[0])]
+            item = data_node[output.name]
             item.get()  # download to host if required
             output_paths.append(item.value)
     return tuple(output_paths) if len(outputs) > 1 else output_paths[0]

--- a/arcana/tasks/bids/tests/test_run_bids_app.py
+++ b/arcana/tasks/bids/tests/test_run_bids_app.py
@@ -45,14 +45,16 @@ def test_run_bids_pipeline(mock_bids_app_executable, cli_runner, nifti_sample_di
     inputs_config = []
     for path, (format, _) in blueprint.expected_formats.items():
         format_str = class_location(format)
-        args.extend(['--input', path2varname(path), format_str, path2varname(path), format_str])
-        inputs_config.append({'path': path, 'format': format_str})
+        varname = path2varname(path)
+        args.extend(['--input', varname, format_str, varname, varname, format_str])
+        inputs_config.append({'name': varname, 'path': path, 'format': format_str})
     args.extend(['--configuration', 'inputs', json.dumps(inputs_config).replace('"', '\\"')])
     outputs_config = []
     for path, _, format, _ in blueprint.derivatives:
         format_str = class_location(format)
-        args.extend(['--output', path, format_str, path2varname(path), format_str])
-        outputs_config.append({'path': path, 'format': format_str})
+        varname = path2varname(path)
+        args.extend(['--output', varname, format_str, varname, varname, format_str])
+        outputs_config.append({'name': varname, 'path': path, 'format': format_str})
     args.extend(['--configuration', 'outputs', json.dumps(outputs_config).replace('"', '\\"')])
     
     result = cli_runner(run_pipeline, args)

--- a/arcana/test/datasets.py
+++ b/arcana/test/datasets.py
@@ -101,7 +101,7 @@ def access_dataset(blueprint, dataset_path):
         space=space,
         hierarchy=blueprint.hierarchy,
         id_inference=blueprint.id_inference)
-    dataset.blueprint = blueprint
+    dataset.blueprint = blueprint  # Stashed in here for future reference by tests
     return dataset
 
 

--- a/arcana/test/fixtures/bids.py
+++ b/arcana/test/fixtures/bids.py
@@ -115,14 +115,17 @@ ENTRYPOINT ["/launch.sh"]""")
 def bids_command_spec(mock_bids_app_executable):
     inputs = [
         {
+            'name': 'T1w',
             'path': 'anat/T1w',
             'format': 'medimage:NiftiGzX'
         },
         {
+            'name': 'T2w',
             'path': 'anat/T2w',
             'format': 'medimage:NiftiGzX'
         },
         {
+            'name': 'DWI',
             'path': 'dwi/dwi',
             'format': 'medimage:NiftiGzXFslgrad'
         },
@@ -130,10 +133,12 @@ def bids_command_spec(mock_bids_app_executable):
     
     outputs = [
         {
+            'name': 'file1',
             'path': 'file1',
             'format': 'common:Text'
         },
         {
+            'name': 'file2',
             'path': 'file2',
             'format': 'common:Text'
         }

--- a/arcana/test/fixtures/common.py
+++ b/arcana/test/fixtures/common.py
@@ -193,13 +193,13 @@ def command_spec():
         'workflow': 'arcana.test.tasks:concatenate',
         'inputs': [
             {
-                'path': 'first-file',
+                'name': 'first_file',
                 'format': 'common:Text',
                 'pydra_field': 'in_file1',
                 'frequency': 'session'
             },
             {
-                'path': 'second-file',
+                'name': 'second_file',
                 'format': 'common:Text',
                 'pydra_field': 'in_file2',
                 'frequency': 'session'
@@ -207,14 +207,14 @@ def command_spec():
         ],
         'outputs': [
             {
-                'path': 'concatenated',
+                'name': 'concatenated',
                 'format': 'common:Text',
                 'pydra_field': 'out_file'
             }
         ],
         'parameters': [
             {
-                'name': 'number-of-duplicates',
+                'name': 'number_of_duplicates',
                 'pydra_field': 'duplicates',
                 'required': True
             }


### PR DESCRIPTION
Restricts the dataset that `run-arcana-pipeline` runs on to a single row of the dataset instead of loading the whole dataset. Avoids problems with the wider data tree blocking the run of pipelines that only operate on individual rows