### PR TITLE
pipeline docs

### DIFF
--- a/arcana/cli/deploy.py
+++ b/arcana/cli/deploy.py
@@ -196,7 +196,8 @@ def build_docs(spec_path, output, flatten, loglevel):
     for spath in walk_spec_paths(spec_path):
         spec = load_yaml_spec(spath, base_dir=spec_path)
         mod_name = spec['_module_name']
-        create_doc(spec, output, mod_name, src_file=spath.relative_to(spec_path), flatten=flatten)
+        src_file = spath.relative_to(Path.cwd())
+        create_doc(spec, output, mod_name, src_file=src_file, flatten=flatten)
         logging.info("Successfully created docs for %s", mod_name)
 
 

--- a/arcana/core/deploy/docs.py
+++ b/arcana/core/deploy/docs.py
@@ -7,7 +7,7 @@ def create_doc(spec, doc_dir, pkg_name, src_file, flatten: bool):
     header = {
         "title": pkg_name,
         "weight": 10,
-        "source_file": str(src_file),
+        "source_file": src_file.as_posix(),
     }
 
     if flatten:

--- a/arcana/core/deploy/docs.py
+++ b/arcana/core/deploy/docs.py
@@ -65,7 +65,7 @@ def create_doc(spec, doc_dir, pkg_name, src_file, flatten: bool):
 
             tbl_cmd = MarkdownTable(f, "Key", "Value")
             tbl_cmd.write_row("Short description", cmd["description"])
-            if cmd.get("workflow"):
+            if cmd.get("pydra_task"):
                 tbl_cmd.write_row("Workflow", escaped_md(cmd["workflow"]))
             if cmd.get("version"):
                 tbl_cmd.write_row("Version", escaped_md(cmd["version"]))

--- a/arcana/core/deploy/docs.py
+++ b/arcana/core/deploy/docs.py
@@ -66,7 +66,7 @@ def create_doc(spec, doc_dir, pkg_name, src_file, flatten: bool):
             tbl_cmd = MarkdownTable(f, "Key", "Value")
             tbl_cmd.write_row("Short description", cmd["description"])
             if cmd.get("pydra_task"):
-                tbl_cmd.write_row("Workflow", escaped_md(cmd["workflow"]))
+                tbl_cmd.write_row("Workflow", escaped_md(cmd["pydra_task"]))
             if cmd.get("version"):
                 tbl_cmd.write_row("Version", escaped_md(cmd["version"]))
             if cmd.get("configuration"):


### PR DESCRIPTION
* Fix incorrect source_file path in the header of the generated pipeline docs, the source_file is used to generate the "Edit this page", etc. links.
* Output more information from pipelines:
   * Required licenses
   * Long&short description
   * Workflow class
   * Pipeline command version
   * Command executable
   * Input descriptions
   * Output descriptions (no pipeline currently has this)