### PR TITLE
Add tests for building docs from pipeline specs #91

### DIFF
--- a/arcana/core/deploy/utils.py
+++ b/arcana/core/deploy/utils.py
@@ -97,20 +97,8 @@ def load_yaml_spec(path: Path, base_dir: Path=None):
         seq = loader.construct_sequence(node)
         return ''.join([str(i) for i in seq])
 
-    def slice(loader, node):
-        list, start, end = loader.construct_sequence(node)
-        return list[start:end]
-
-    def sliceeach(loader, node):
-        _, start, end = loader.construct_sequence(node)
-        return [
-            loader.construct_sequence(x)[start:end] for x in node.value[0].value
-        ]
-
     yaml.SafeLoader.add_constructor(tag='!join', constructor=concat)
     yaml.SafeLoader.add_constructor(tag='!concat', constructor=concat)
-    yaml.SafeLoader.add_constructor(tag='!slice', constructor=slice)
-    yaml.SafeLoader.add_constructor(tag='!sliceeach', constructor=sliceeach)
 
     with open(path, 'r') as f:
         data = yaml.load(f, Loader=yaml.SafeLoader)

--- a/arcana/core/deploy/utils.py
+++ b/arcana/core/deploy/utils.py
@@ -120,6 +120,9 @@ def load_yaml_spec(path: Path, base_dir: Path=None):
     #     # TODO: Handle other row_frequency types, are there any?
     #     data['row_frequency'] = Clinical[row_frequency.split('.')[-1]]
 
+    if type(data) is not dict:
+        raise ValueError(f"{path!r} didn't contain a dict!")
+
     data['_relative_dir'] = os.path.dirname(os.path.relpath(path, base_dir)) if base_dir else ''
     data['_module_name'] = os.path.basename(path).rsplit('.', maxsplit=1)[0]
 

--- a/arcana/test/fixtures/docs.py
+++ b/arcana/test/fixtures/docs.py
@@ -1,0 +1,183 @@
+from typing import Iterable, Union, List
+
+
+class DocsFixture:
+    def __init__(self, yaml_src: str, markdown: str):
+        self.yaml_src = yaml_src
+        self.markdown = markdown
+
+
+minimal_doc_spec = DocsFixture(
+    """
+pkg_version: &pkg_version '0.16.1'
+wrapper_version: '1.10'
+commands: []
+    """.strip(),
+    """
+---
+source_file: spec.yaml
+title: spec
+weight: 10
+
+---
+
+## Package Info
+|Key|Value|
+|---|-----|
+|App version|0.16.1|
+|XNAT wrapper version|1.10|
+
+## Commands
+    """.strip()
+)
+
+yaml_constructors_join_spec = DocsFixture(
+    """
+pkg_version: &pkg_version '0.16.1'
+wrapper_version: '1.10'
+base_image: !join [ 'abc', *pkg_version ]
+commands: []
+    """.strip(),
+    """
+---
+source_file: spec.yaml
+title: spec
+weight: 10
+
+---
+
+## Package Info
+|Key|Value|
+|---|-----|
+|App version|0.16.1|
+|XNAT wrapper version|1.10|
+|Base image|`abc0.16.1`|
+
+## Commands
+    """.strip()
+)
+
+yaml_constructors_concat_spec = DocsFixture(
+    """
+pkg_version: &pkg_version '0.16.1'
+wrapper_version: '1.10'
+base_image: !concat [ 'abc', *pkg_version ]
+commands: []
+    """.strip(),
+    """
+---
+source_file: spec.yaml
+title: spec
+weight: 10
+
+---
+
+## Package Info
+|Key|Value|
+|---|-----|
+|App version|0.16.1|
+|XNAT wrapper version|1.10|
+|Base image|`abc0.16.1`|
+
+## Commands
+    """.strip()
+)
+
+complete_doc_spec = DocsFixture(
+    """
+pkg_version: &pkg_version '0.16.1'
+wrapper_version: '1.10'
+authors:
+  - author_field
+base_image: !join [ 'abc', *pkg_version ]
+info_url: https://example.com
+package_manager: apt
+system_packages: []
+python_packages:
+  - name: pydra
+  - name: pydra-dcm2niix
+package_templates:
+  - name: dcm2niix
+    version: v1.0.20201102
+commands:
+  - name: mriqc
+    version: 1a1
+    workflow: arcana.tasks.bids:bids_app
+    description: a description
+    long_description: >-
+      a longer description
+    inputs: &inputs
+      - name: T1w
+        path: anat/T1w
+        format: medimage:NiftiGzX
+        stored_format: medimage:Dicom
+        description: "T1-weighted anatomical scan"
+      - name: T2w
+        path: anat/T2w
+        format: medimage:NiftiGzX
+        stored_format: medimage:Dicom
+        description: "T2-weighted anatomical scan"
+      - name: fMRI
+        path: func/task-rest_bold
+        format: medimage:NiftiGzX
+        stored_format: medimage:Dicom
+        description: "functional MRI"
+    outputs: &outputs
+      - name: mriqc
+        path: mriqc
+        format: common:Directory
+    parameters:
+    frequency: session
+    configuration:
+      inputs: *inputs
+      outputs: *outputs
+      executable: /usr/local/miniconda/bin/mriqc
+      dataset: /work/bids-dataset
+      app_output_dir: /work/bids-app-output
+    """.strip(),
+    """
+---
+source_file: spec.yaml
+title: spec
+weight: 10
+
+---
+
+## Package Info
+|Key|Value|
+|---|-----|
+|App version|0.16.1|
+|XNAT wrapper version|1.10|
+|Base image|`abc0.16.1`|
+|Info URL|https://example.com|
+
+## Commands
+### mriqc
+a longer description
+
+|Key|Value|
+|---|-----|
+|Short description|a description|
+|Version|`1a1`|
+|Executable|`/usr/local/miniconda/bin/mriqc`|
+#### Inputs
+|Path|Input format|Stored format|Description|
+|----|------------|-------------|-----------|
+|`T1w`|`medimage:NiftiGzX`|`medimage:Dicom`|T1-weighted anatomical scan|
+|`T2w`|`medimage:NiftiGzX`|`medimage:Dicom`|T2-weighted anatomical scan|
+|`fMRI`|`medimage:NiftiGzX`|`medimage:Dicom`|functional MRI|
+
+#### Outputs
+|Name|Output format|Stored format|Description|
+|----|-------------|-------------|-----------|
+|`mriqc`|`common:Directory`|`format`||
+    """.strip()
+)
+
+
+def all_docs_fixtures() -> Iterable[Union[DocsFixture, List[DocsFixture]]]:
+    from . import docs
+
+    for k, v in docs.__dict__.items():
+        if type(v) is DocsFixture or (type(v) is list and type(v[0]) is DocsFixture):
+            yield k, v


### PR DESCRIPTION
* Add docs generation tests
* Fix error when building docs for specs that aren't under the current working directory
* Remove `!slice` and `!sliceeach`