### PR TITLE
Bug fix for alternative location of vcs information in direct_url.json

### DIFF
--- a/arcana/core/deploy/utils.py
+++ b/arcana/core/deploy/utils.py
@@ -210,10 +210,11 @@ def local_package_location(pip_spec: PipSpec, pypi_fallback: bool = False):
             with open(direct_url_path) as f:
                 url_spec = json.load(f)
             url = url_spec["url"]
-            if "vcs" in url_spec:
-                url = url_spec["vcs"] + "+" + url
-            if "commit_id" in url_spec:
-                url += "@" + url_spec["commit_id"]
+            vcs_info = url_spec.get('vcs_info', url_spec)  # Fallback to trying to find VCS info in the base url-spec dict
+            if 'vcs' in vcs_info:
+                url = vcs_info['vcs'] + '+' + url
+            if 'commit_id' in vcs_info:
+                url += '@' + vcs_info['commit_id']
             pip_spec = PipSpec(name=pip_spec.name, url=url, extras=pip_spec.extras)
         else:
             pip_spec = PipSpec(

--- a/arcana/core/deploy/utils.py
+++ b/arcana/core/deploy/utils.py
@@ -211,11 +211,16 @@ def local_package_location(pip_spec: PipSpec, pypi_fallback: bool = False):
                 url_spec = json.load(f)
             url = url_spec["url"]
             vcs_info = url_spec.get('vcs_info', url_spec)  # Fallback to trying to find VCS info in the base url-spec dict
-            if 'vcs' in vcs_info:
-                url = vcs_info['vcs'] + '+' + url
-            if 'commit_id' in vcs_info:
-                url += '@' + vcs_info['commit_id']
-            pip_spec = PipSpec(name=pip_spec.name, url=url, extras=pip_spec.extras)
+            if url.startswith('file://'):
+                pip_spec = PipSpec(
+                    name=pip_spec.name, file_path=url[len('file://'):], extras=pip_spec.extras)
+            else:
+                vcs_info = url_spec.get('vcs_info', url_spec)
+                if 'vcs' in vcs_info:
+                    url = vcs_info['vcs'] + '+' + url
+                if 'commit_id' in vcs_info:
+                    url += '@' + vcs_info['commit_id']
+                pip_spec = PipSpec(name=pip_spec.name, url=url, extras=pip_spec.extras)
         else:
             pip_spec = PipSpec(
                 name=pip_spec.name, version=pkg.version, extras=pip_spec.extras


### PR DESCRIPTION
It seems as though if a package is installed from a local copy into the site-packages the location of the VCS info is slightly different than if it is installed in editable mode (either that or it is changed in newer versions). Handle this case by attempting to get the information from 'vcs_info' key, falling back to the base dictionary (where it used to be stored)